### PR TITLE
change gradle runtime dependecy scope to compileOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ if(isSetupForDeployToMavenCentral()) {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.8'
+    gradleVersion = '4.3.1'
 }
 
 task downloadDeps << {

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,11 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.codehaus.groovy', name: 'groovy-all', version: '2.4.12'
-    compile 'com.opencsv:opencsv:4.0'
-    testCompile "org.spockframework:spock-core:1.1-groovy-2.4-rc-2"
-    testCompile "cglib:cglib-nodep:2.2"
-    testCompile "org.objenesis:objenesis:1.2"
+    compile 	'com.opencsv:opencsv:4.0'
+    compileOnly 'org.codehaus.groovy:groovy-all:1.8.8'
+    testCompile 'org.spockframework:spock-core:1.1-groovy-2.4-rc-2'
+    testCompile 'cglib:cglib-nodep:2.2'
+    testCompile 'org.objenesis:objenesis:1.2'
 }
 
 version = '1.3-SNAPSHOT'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip


### PR DESCRIPTION
The gradle runtime should not be in compile scope. I changed it to compileOnly which is the equivalent to the provided scope in maven.