### PR TITLE
Don't throw Array out of bounce exception, if line is too short

### DIFF
--- a/src/com/xlson/groovycsv/PropertyMapper.groovy
+++ b/src/com/xlson/groovycsv/PropertyMapper.groovy
@@ -48,6 +48,9 @@ class PropertyMapper {
     def propertyMissing(String name) {
         def index = columns[name]
         if (index != null) {
+            if(values?.size() <= index) {
+                return null
+            }
             values[index]
         } else {
             throw new MissingPropertyException(name)

--- a/test/com/xlson/groovycsv/CsvParserSpec.groovy
+++ b/test/com/xlson/groovycsv/CsvParserSpec.groovy
@@ -290,4 +290,19 @@ h,drink,60'''
         line["Word"] == "paris"
         line["Number"] == "5"
     }
+
+    def "CsvParser and different cardinality lines"() {
+        given:
+        def csvWithDifferentCardinality = '''header1,header2,header3
+val1,val2
+val1,val2,val3'''
+
+        when:
+        def csv = new CsvParser().parse(csvWithDifferentCardinality)
+        def line = csv.next()
+
+        then:
+        line["header3"] == null
+
+    }
 }


### PR DESCRIPTION
When a line has fewer values than the headers, an ArrayOutOfBound exception is thrown.
This makes it return null instead. If you prefer MissingPropertyException I can update the PR.